### PR TITLE
VarHandles not Unsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 
 	<properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler.source>1.6</compiler.source>
-        <compiler.target>1.6</compiler.target>
+        <compiler.source>9</compiler.source>
+        <compiler.target>9</compiler.target>
         <testng.version>6.3.1</testng.version>
         <maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.12</maven-surefire-plugin.version>


### PR DESCRIPTION
On Java 9+ there is a new class VarHandle that allows reading a byte[] as a long[] without resorting to Unsafe.  Benchmarks appear to be nearly identical with the unsafe branch...maybe a tiny bit faster. 

Just going to put this draft PR here. Not asking for anything to be merged or any action to happen.