### PR TITLE
Fix Digest#update(byte[], int, int)

### DIFF
--- a/src/main/java/ove/crypto/digest/Blake2b.java
+++ b/src/main/java/ove/crypto/digest/Blake2b.java
@@ -576,9 +576,9 @@ public interface Blake2b {
 			}
 		}
 
-		static long[] copyMemory(byte[] src, long[] dst) {
+		static long[] copyMemory(byte[] src, long[] dst, int offset) {
 			for(int i = 0; i < 16; i++) {
-				dst[i] = (long) longView.get(src, i*8);
+				dst[i] = (long) longView.get(src, offset + i*8);
 			}
 			return dst;
 		}
@@ -588,7 +588,7 @@ public interface Blake2b {
 
 			// set m registers
 			// the copy will init m with little endian semantics.
-			final long[] m = copyMemory(b, state.m);
+			final long[] m = copyMemory(b, state.m, offset);
 
 			// set v registers
 			final   long[]  v = state.v;

--- a/src/test/java/ove/crypto/digest/TestDigestAbstractBase.java
+++ b/src/test/java/ove/crypto/digest/TestDigestAbstractBase.java
@@ -23,6 +23,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.*;
+import java.util.Random;
 
 import static ove.test.Utils.*;
 import static ove.crypto.digest.Blake2BTestUtils.*;
@@ -98,5 +99,30 @@ abstract public class TestDigestAbstractBase extends Blake2bTestsBase {
 		// check
 		byte[] testBytes = baos.toByteArray();
 		Assert.assertEquals ( testBytes, refbytes, "does not match reference KAT");
+	}
+
+	/**
+	 * Verify that {@link Blake2b.Digest#update(byte[], int, int)} behaves the same whether the data is at offset 0 or
+	 * a non-zero offset.
+	 */
+	@Test(suiteName = "blake2b")
+	public void testUpdateWithNonZeroOffset()  {
+		logit (this, "testUpdateWithNonZeroOffset");
+		Random random = new Random();
+		byte[] bytesToHash = new byte[1024];
+		random.nextBytes(bytesToHash);
+
+		byte[] bytesWithOffset = new byte[1030];
+		System.arraycopy(bytesToHash, 0, bytesWithOffset, 6, bytesToHash.length);
+
+		Blake2b digest = newMessageDigest();
+		digest.update(bytesToHash, 0, bytesToHash.length);
+		byte[] zeroOffsetHash = digest.digest();
+
+		digest.reset();
+		digest.update(bytesWithOffset, 6, bytesToHash.length);
+		byte[] positiveOffsetHash = digest.digest();
+
+		Assert.assertEquals(positiveOffsetHash, zeroOffsetHash);
 	}
 }


### PR DESCRIPTION
The update(byte[], int, int) function produced an incorrect hash when used with a non-zero offset.

The root cause was that the compress(byte[], int) function did not pass the offset to copyMemory(byte[], byte[]).